### PR TITLE
Achievements and behaviors

### DIFF
--- a/tourney/achievements/__init__.py
+++ b/tourney/achievements/__init__.py
@@ -1,5 +1,7 @@
 from .win_behavior import WinBehavior
+from .achievements import Achievements
 
 __all__ = [
-  "WinBehavior"
+  "WinBehavior",
+  "Achievements"
 ]

--- a/tourney/achievements/__init__.py
+++ b/tourney/achievements/__init__.py
@@ -1,0 +1,5 @@
+from .win_behavior import WinBehavior
+
+__all__ = [
+  "WinBehavior"
+]

--- a/tourney/achievements/__init__.py
+++ b/tourney/achievements/__init__.py
@@ -1,7 +1,13 @@
-from .win_behavior import WinBehavior
 from .achievements import Achievements
 
+from .win_behavior import WinBehavior
+from .invoke_behavior import InvokeBehavior
+
 __all__ = [
+  # General.
+  "Achievements",
+
+  # Behaviors.
   "WinBehavior",
-  "Achievements"
+  "InvokeBehavior"
 ]

--- a/tourney/achievements/achievement.py
+++ b/tourney/achievements/achievement.py
@@ -36,3 +36,15 @@ class Achievement(ABC):
     """Update achievement progress given behavior.
     Must return True if achievement was obtained, and False otherwise."""
     pass
+
+  @abstractmethod
+  def achieved(self, user_id):
+    """Whether or not user achived the achievement."""
+    pass
+
+  def current_progress(self, user_id):
+    """Returns formatted string of current progress for user."""
+    res = "{}: {}".format(self.name(), self.description())
+    if self.achieved(user_id):
+      res += " :+1:"
+    return res

--- a/tourney/achievements/achievement.py
+++ b/tourney/achievements/achievement.py
@@ -1,0 +1,40 @@
+from abc import ABC, abstractmethod
+
+class Achievement(ABC):
+  """Achievement encapsulates a player's progress to obtain an achievement."""
+
+  def __init__(self, kind):
+    self.__kind = kind
+    self.__data = {} # User ID -> achievement data.
+
+  def kind(self):
+    return self.__kind
+
+  def data(self):
+    return self.__data
+
+  def set_data(self, data):
+    self.__data = data
+
+  @abstractmethod
+  def name(self):
+    """Name of achievement."""
+    pass
+
+  @abstractmethod
+  def description(self):
+    """Description of achievement."""
+    pass
+
+  @abstractmethod
+  def accepted_behaviors(self):
+    """List of accepted behavior kinds."""
+    pass
+
+  def accepts(self, behavior_kind):
+    return behavior_kind in self.accepted_behaviors()
+
+  @abstractmethod
+  def update(self, behavior):
+    """Update achievement progress given behavior."""
+    pass

--- a/tourney/achievements/achievement.py
+++ b/tourney/achievements/achievement.py
@@ -39,7 +39,8 @@ class Achievement(ABC):
 
   @abstractmethod
   def achieved(self, user_id):
-    """Whether or not user achived the achievement."""
+    """Whether or not user achived the achievement. For multi-tiered achievements it must always
+    yield True after the first tier is achieved."""
     pass
 
   @abstractmethod

--- a/tourney/achievements/achievement.py
+++ b/tourney/achievements/achievement.py
@@ -42,9 +42,36 @@ class Achievement(ABC):
     """Whether or not user achived the achievement."""
     pass
 
+  @abstractmethod
+  def progress(self, user_id):
+    """Achievement progress."""
+    pass
+
+  @abstractmethod
+  def next_tier(self, user_id):
+    """Progress to reach for next achievement tier.
+    Returns None if no next tier is available."""
+    pass
+
+  @abstractmethod
+  def tiered_name(self, user_id):
+    """Name of the highest achieved achievement name if multi-tiered."""
+    pass
+
+  @abstractmethod
+  def tiered_description(self, user_id):
+    """Description of the highest achieved achievement name if multi-tiered."""
+    pass
+
   def current_progress(self, user_id):
     """Returns formatted string of current progress for user."""
-    res = "{}: {}".format(self.name(), self.description())
-    if self.achieved(user_id):
-      res += " :+1:"
+    res = "{}: {}".format(self.tiered_name(user_id), self.tiered_description(user_id))
+    nt = self.next_tier(user_id)
+    if nt is None:
+      if self.achieved(user_id):
+        res += " :+1:"
+      else:
+        res += " :-1:"
+    else:
+      res += " ({}/{})".format(self.progress(user_id), nt)
     return res

--- a/tourney/achievements/achievement.py
+++ b/tourney/achievements/achievement.py
@@ -5,16 +5,13 @@ class Achievement(ABC):
 
   def __init__(self, kind):
     self.__kind = kind
-    self.__data = {} # User ID -> achievement data.
+    self.data = {} # User ID -> achievement data.
 
   def kind(self):
     return self.__kind
 
-  def data(self):
-    return self.__data
-
   def set_data(self, data):
-    self.__data = data
+    self.data = data
 
   @abstractmethod
   def name(self):
@@ -36,5 +33,6 @@ class Achievement(ABC):
 
   @abstractmethod
   def update(self, behavior):
-    """Update achievement progress given behavior."""
+    """Update achievement progress given behavior.
+    Must return True if achievement was obtained, and False otherwise."""
     pass

--- a/tourney/achievements/achievement.py
+++ b/tourney/achievements/achievement.py
@@ -64,14 +64,10 @@ class Achievement(ABC):
     pass
 
   def current_progress(self, user_id):
-    """Returns formatted string of current progress for user."""
+    """Returns formatted string of current progress for user.
+    Expects the achievement to be achieved or in progress when called."""
     res = "{}: {}".format(self.tiered_name(user_id), self.tiered_description(user_id))
     nt = self.next_tier(user_id)
-    if nt is None:
-      if self.achieved(user_id):
-        res += " :+1:"
-      else:
-        res += " :-1:"
-    else:
+    if nt is not None:
       res += " ({}/{})".format(self.progress(user_id), nt)
     return res

--- a/tourney/achievements/achievements.py
+++ b/tourney/achievements/achievements.py
@@ -36,6 +36,13 @@ class Achievements:
     # TODO: Post to slack!
     print("{} achieved: {}".format(user_id, achiev.current_progress(user_id)))
 
+  def user_response(self, user_id):
+    """Returns formatted response with user progress of all achievements."""
+    res = []
+    for achiev in self.__achievements:
+      res.append(achiev.current_progress(user_id))
+    return "Achievements progress:\n\t" + "\n\t".join(res)
+
   def file_path(self):
     return os.path.expanduser("{}/achievements.json".format(DATA_PATH))
 

--- a/tourney/achievements/achievements.py
+++ b/tourney/achievements/achievements.py
@@ -28,10 +28,13 @@ class Achievements:
   def interact(self, behavior):
     """Interact given specified behavior and update with each achievement accepting it."""
     for achiev in self.__achievements:
-      if achiev.accepts(behavior.kind()):
-        achiev.update(behavior)
-        # TODO: Check if achievement was obtained via the behavior.
+      if achiev.accepts(behavior.kind()) and achiev.update(behavior):
+        self.__broadcast_achievement(behavior.user_id(), achiev)
     self.save()
+
+  def __broadcast_achievement(self, user_id, achiev):
+    # TODO: Post to slack!
+    print("{} achieved: {}".format(user_id, achiev.current_progress(user_id)))
 
   def file_path(self):
     return os.path.expanduser("{}/achievements.json".format(DATA_PATH))

--- a/tourney/achievements/achievements.py
+++ b/tourney/achievements/achievements.py
@@ -46,7 +46,7 @@ class Achievements:
     # Serialize each achievement instance's data and save as kind -> data.
     achiev_data = {}
     for achiev in self.__achievements:
-      achiev_data[achiev.kind()] = achiev.data()
+      achiev_data[achiev.kind()] = achiev.data
     data = {
       "data": achiev_data
     }

--- a/tourney/achievements/achievements.py
+++ b/tourney/achievements/achievements.py
@@ -41,8 +41,10 @@ class Achievements:
     """Returns formatted response with user progress of all achievements."""
     res = []
     for achiev in self.__achievements:
-      if achiev.achieved(user_id) or achiev.progress(user_id) > 0:
+      if achiev.achieved(user_id):
         res.append(achiev.current_progress(user_id))
+    if len(res) == 0:
+      return "No achievements yet!"
     return "Achievements progress:\n\t" + "\n\t".join(res)
 
   def file_path(self):

--- a/tourney/achievements/achievements.py
+++ b/tourney/achievements/achievements.py
@@ -1,6 +1,8 @@
 import os
 import json
 
+from .rtfm_achievement import RtfmAchievement
+
 from tourney.constants import DATA_PATH
 
 class Achievements:
@@ -23,18 +25,29 @@ class Achievements:
       return Achievements()
     return Achievements.__instance
 
+  def interact(self, behavior):
+    """Interact given specified behavior and update with each achievement accepting it."""
+    for achiev in self.__achievements:
+      if achiev.accepts(behavior.kind()):
+        achiev.update(behavior)
+        # TODO: Check if achievement was obtained via the behavior.
+
   def file_path(self):
     return os.path.expanduser("{}/achievements.json".format(DATA_PATH))
 
   def reset(self):
     # Achievement instances.
-    self.__achievements = []
-    # TODO: Lead each kind of achievement as instances.
+    self.__achievements = [
+      RtfmAchievement()
+    ]
 
   def save(self):
-    # TODO: Serialize each achievement instance's data and save as kind -> data.
+    # Serialize each achievement instance's data and save as kind -> data.
+    achiev_data = {}
+    for achiev in self.__achievements:
+      achiev_data[achiev.kind()] = achiev.data()
     data = {
-      "data": {}
+      "data": achiev_data
     }
     os.makedirs(os.path.dirname(self.file_path()), exist_ok=True)
     with open(self.file_path(), "w+") as fp:
@@ -44,5 +57,8 @@ class Achievements:
     with open(self.file_path(), "r") as fp:
       data = json.load(fp)
       if "data" in data:
-        # TODO: Deserialize each kind -> data for associated achievement instance.
-        pass
+        # Deserialize each kind -> data for associated achievement instance.
+        achiev_data = data["data"]
+        for achiev in self.__achievements:
+          if achiev.kind() in achiev_data:
+            achiev.set_data(achiev_data[achiev.kind()])

--- a/tourney/achievements/achievements.py
+++ b/tourney/achievements/achievements.py
@@ -2,6 +2,7 @@ import os
 import json
 
 from .rtfm_achievement import RtfmAchievement
+from .commander_achievement import CommanderAchievement
 
 from tourney.constants import DATA_PATH
 
@@ -50,7 +51,8 @@ class Achievements:
   def reset(self):
     # Achievement instances.
     self.__achievements = [
-      RtfmAchievement()
+      RtfmAchievement(),
+      CommanderAchievement()
     ]
 
   def save(self):

--- a/tourney/achievements/achievements.py
+++ b/tourney/achievements/achievements.py
@@ -31,6 +31,7 @@ class Achievements:
       if achiev.accepts(behavior.kind()):
         achiev.update(behavior)
         # TODO: Check if achievement was obtained via the behavior.
+    self.save()
 
   def file_path(self):
     return os.path.expanduser("{}/achievements.json".format(DATA_PATH))

--- a/tourney/achievements/achievements.py
+++ b/tourney/achievements/achievements.py
@@ -1,0 +1,48 @@
+import os
+import json
+
+from tourney.constants import DATA_PATH
+
+class Achievements:
+  __instance = None
+
+  def __init__(self):
+    if not Achievements.__instance:
+      self.reset()
+      try:
+        self.load()
+      except Exception as ex:
+        print("Achievements file could not load: {}".format(self.file_path()))
+        print(ex)
+
+      Achievements.__instance = self
+
+  @staticmethod
+  def get():
+    if not Achievements.__instance:
+      return Achievements()
+    return Achievements.__instance
+
+  def file_path(self):
+    return os.path.expanduser("{}/achievements.json".format(DATA_PATH))
+
+  def reset(self):
+    # Achievement instances.
+    self.__achievements = []
+    # TODO: Lead each kind of achievement as instances.
+
+  def save(self):
+    # TODO: Serialize each achievement instance's data and save as kind -> data.
+    data = {
+      "data": {}
+    }
+    os.makedirs(os.path.dirname(self.file_path()), exist_ok=True)
+    with open(self.file_path(), "w+") as fp:
+      json.dump(data, fp, indent=2)
+
+  def load(self):
+    with open(self.file_path(), "r") as fp:
+      data = json.load(fp)
+      if "data" in data:
+        # TODO: Deserialize each kind -> data for associated achievement instance.
+        pass

--- a/tourney/achievements/achievements.py
+++ b/tourney/achievements/achievements.py
@@ -40,7 +40,8 @@ class Achievements:
     """Returns formatted response with user progress of all achievements."""
     res = []
     for achiev in self.__achievements:
-      res.append(achiev.current_progress(user_id))
+      if achiev.achieved(user_id) or achiev.progress(user_id) > 0:
+        res.append(achiev.current_progress(user_id))
     return "Achievements progress:\n\t" + "\n\t".join(res)
 
   def file_path(self):

--- a/tourney/achievements/behavior.py
+++ b/tourney/achievements/behavior.py
@@ -1,0 +1,17 @@
+from abc import ABC, abstractmethod
+
+# Kinds of behaviors.
+WIN_BEHAVIOR = 0 # Win a game.
+
+class Behavior(ABC):
+  """Behavior encapsulates behavior observed from users."""
+
+  def __init__(self, kind, user_id):
+    self.__kind = kind
+    self.__user_id = user_id
+
+  def kind(self):
+    return self.__kind
+
+  def user_id(self):
+    return self.__user_id

--- a/tourney/achievements/behavior.py
+++ b/tourney/achievements/behavior.py
@@ -1,7 +1,8 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 
 # Kinds of behaviors.
-WIN_BEHAVIOR = 0 # Win a game.
+INVOKE_BEHAVIOR = 0 # Invoke a command.
+WIN_BEHAVIOR = 1 # Win a game.
 
 class Behavior(ABC):
   """Behavior encapsulates behavior observed from users."""

--- a/tourney/achievements/commander_achievement.py
+++ b/tourney/achievements/commander_achievement.py
@@ -1,0 +1,70 @@
+from .achievement import Achievement
+from .behavior import INVOKE_BEHAVIOR
+
+TIERS = (
+  (10,  "Commander",                    "Invoke 10 commands."),
+  (20,  "Commander Lieutenant",         "Invoke 20 commands."),
+  (30,  "Commander Captain",            "Invoke 30 commands."),
+  (40,  "Commander Major",              "Invoke 40 commands."),
+  (50,  "Commander Major General",      "Invoke 50 commands."),
+  (75,  "Commander Lieutenant General", "Invoke 75 commands."),
+  (150, "Commander General",            "Invoke 150 commands."),
+  (300, "Commander Field Marshal",      "Invoke 300 commands."),
+)
+
+class CommanderAchievement(Achievement):
+  def __init__(self):
+    super(CommanderAchievement, self).__init__("Commander")
+
+  def name(self):
+    return TIERS[0][1]
+
+  def description(self):
+    return TIERS[0][2]
+
+  def accepted_behaviors(self):
+    return [INVOKE_BEHAVIOR]
+
+  def update(self, behavior):
+    user_id = behavior.user_id()
+    self.__check_init(user_id)
+    self.data[user_id][0] += 1
+    amount = self.data[user_id][0]
+    if amount == self.next_tier(user_id):
+      self.data[user_id][1] += 1
+      return True
+    return False
+
+  def achieved(self, user_id):
+    self.__check_init(user_id)
+    return self.data[user_id][1] >= 0
+
+  def progress(self, user_id):
+    self.__check_init(user_id)
+    return self.data[user_id][0]
+
+  def next_tier(self, user_id):
+    self.__check_init(user_id)
+    tier = self.data[user_id][1]
+    return TIERS[tier+1][0]
+
+  def tiered_name(self, user_id):
+    self.__check_init(user_id)
+    tier = self.data[user_id][1]
+    if tier == -1:
+      return self.name()
+    return TIERS[tier][1]
+
+  def tiered_description(self, user_id):
+    self.__check_init(user_id)
+    tier = self.data[user_id][1]
+    if tier == -1:
+      return self.description()
+    return TIERS[tier][2]
+
+  def __check_init(self, user_id):
+    if user_id not in self.data:
+      self.data[user_id] = [
+         0, # Command amount
+        -1, # Tier
+      ]

--- a/tourney/achievements/invoke_behavior.py
+++ b/tourney/achievements/invoke_behavior.py
@@ -1,0 +1,9 @@
+from .behavior import Behavior, INVOKE_BEHAVIOR
+
+class InvokeBehavior(Behavior):
+  def __init__(self, user_id, command_name):
+    super(InvokeBehavior, self).__init__(INVOKE_BEHAVIOR, user_id)
+    self.__command_name = command_name
+
+  def command_name(self):
+    return self.__command_name

--- a/tourney/achievements/rtfm_achievement.py
+++ b/tourney/achievements/rtfm_achievement.py
@@ -15,5 +15,10 @@ class RtfmAchievement(Achievement):
     return [INVOKE_BEHAVIOR]
 
   def update(self, behavior):
-    # TODO: React to whether the command is "help" or not.
-    pass
+    user_id = behavior.user_id()
+    if not user_id in self.data:
+      self.data[user_id] = False
+    if behavior.command_name() == "help" and not self.data[user_id]:
+      self.data[user_id] = True
+      return True
+    return False

--- a/tourney/achievements/rtfm_achievement.py
+++ b/tourney/achievements/rtfm_achievement.py
@@ -25,3 +25,15 @@ class RtfmAchievement(Achievement):
 
   def achieved(self, user_id):
     return user_id in self.data and self.data[user_id]
+
+  def progress(self, user_id):
+    return 0
+
+  def next_tier(self, user_id):
+    return None
+
+  def tiered_name(self, user_id):
+    return self.name()
+
+  def tiered_description(self, user_id):
+    return self.description()

--- a/tourney/achievements/rtfm_achievement.py
+++ b/tourney/achievements/rtfm_achievement.py
@@ -1,0 +1,19 @@
+from .achievement import Achievement
+from .behavior import INVOKE_BEHAVIOR
+
+class RtfmAchievement(Achievement):
+  def __init__(self):
+    super(RtfmAchievement, self).__init__("RTFM")
+
+  def name(self):
+    return "RTFM"
+
+  def description(self):
+    return "Use the !help command."
+
+  def accepted_behaviors(self):
+    return [INVOKE_BEHAVIOR]
+
+  def update(self, behavior):
+    # TODO: React to whether the command is "help" or not.
+    pass

--- a/tourney/achievements/rtfm_achievement.py
+++ b/tourney/achievements/rtfm_achievement.py
@@ -22,3 +22,6 @@ class RtfmAchievement(Achievement):
       self.data[user_id] = True
       return True
     return False
+
+  def achieved(self, user_id):
+    return user_id in self.data and self.data[user_id]

--- a/tourney/achievements/win_behavior.py
+++ b/tourney/achievements/win_behavior.py
@@ -1,0 +1,5 @@
+from .behavior import Behavior, WIN_BEHAVIOR
+
+class WinBehavior(Behavior):
+  def __init__(self, user_id):
+    super(WinBehavior, self).__init__(WIN_BEHAVIOR, user_id)

--- a/tourney/commands/__init__.py
+++ b/tourney/commands/__init__.py
@@ -7,6 +7,7 @@ from .win_lose_command import WinLoseCommand
 from .stats_command import StatsCommand
 from .mystats_command import MyStatsCommand
 from .undoteams_command import UndoTeamsCommand
+from .achievements_command import AchievementsCommand
 
 __all__ = [
   "HelpCommand",
@@ -17,5 +18,6 @@ __all__ = [
   "WinLoseCommand",
   "StatsCommand",
   "MyStatsCommand",
-  "UndoTeamsCommand"
+  "UndoTeamsCommand",
+  "AchievementsCommand"
 ]

--- a/tourney/commands/__init__.py
+++ b/tourney/commands/__init__.py
@@ -1,4 +1,3 @@
-from . import command
 from .help_command import HelpCommand
 from .list_command import ListCommand
 from .join_command import JoinCommand
@@ -10,7 +9,6 @@ from .mystats_command import MyStatsCommand
 from .undoteams_command import UndoTeamsCommand
 
 __all__ = [
-  "command",
   "HelpCommand",
   "ListCommand",
   "JoinCommand",

--- a/tourney/commands/achievements_command.py
+++ b/tourney/commands/achievements_command.py
@@ -1,0 +1,13 @@
+import itertools
+
+from .command import Command
+
+from tourney.achievements import Achievements
+
+class AchievementsCommand(Command):
+  def __init__(self):
+    super(AchievementsCommand, self).__init__("achievements")
+
+  def execute(self, lookup=None):
+    achievements = Achievements.get()
+    return achievements.user_response(self.user_id())

--- a/tourney/commands/help_command.py
+++ b/tourney/commands/help_command.py
@@ -18,6 +18,7 @@ As the foosball bot, I accept the following commands:
   `!score` - Add match scores of two teams. Example: `!score T0 12 T3 16`
   `!stats` - Prints general statistics of all games.
   `!mystats` - Prints statistics of all games about invoker.
+  `!achievements` - Prints achievements progress for invoker.
   `!undoteams` - Undoes teams and matches and restores as players joined. (*privileged!*)
   `!generate` - Generate teams and matches from players joined. (*privileged!*)
   `!autoupdate` - Updates project git repo and restarts bot. (*privileged!*)

--- a/tourney/main.py
+++ b/tourney/main.py
@@ -227,14 +227,20 @@ def handle_command(cmd):
 
 def scheduled_actions():
   """Execute actions at scheduled times."""
+  state = State.get()
+  channel_id = state.channel_id()
+
+  # Check if any obtained achievements should be broadcast.
+  achievements = Achievements.get()
+  for (user_id, text) in achievements.scheduled_broadcasts():
+    user_name = lookup.user_name_by_id(user_id)
+    response = "{} obtained achievement: *{}*".format(user_name, text)
+    client.api_call("chat.postMessage", channel=channel_id, text=response)
 
   # Ignore on saturdays and sundays.
   now = datetime.today()
   if now.weekday() >= 5:
     return
-
-  state = State.get()
-  channel_id = state.channel_id()
 
   # Morning announcement for participants to join game.
   start = datetime.combine(date.today(), MORNING_ANNOUNCE)

--- a/tourney/main.py
+++ b/tourney/main.py
@@ -205,12 +205,15 @@ def handle_command(cmd):
   if not channel_id:
     channel_id = state.channel_id()
   participants = state.participants()
+  achievements = Achievements.get()
 
   response = None
   if not cmd.allowed():
     response = "`!{}` is a privileged command and you're not allowed to use it!".format(command)
   else:
     response = cmd.execute(lookup)
+    # TODO: Should it only accept behavior if command executed without errors?
+    achievements.interact(InvokeBehavior(user_id, command))
 
   if response is None:
     response = "Unknown command! Try `!help` for supported commands."

--- a/tourney/main.py
+++ b/tourney/main.py
@@ -14,6 +14,7 @@ from .scores import Scores
 from .config import Config
 from .stats import Stats
 from .util import command_allowed
+from .achievements import *
 
 bot_token = os.environ.get("TOURNEY_BOT_TOKEN")
 client = SlackClient(bot_token)
@@ -294,6 +295,7 @@ def init():
   state = State.get()
   scores = Scores.get()
   stats = Stats.get()
+  achievements = Achievements.get()
 
   if len(config.privileged_users()) == 0:
     print("No privileged users defined in config!")

--- a/tourney/main.py
+++ b/tourney/main.py
@@ -127,6 +127,8 @@ def parse_command(event):
     cmd = MyStatsCommand()
   elif command == "undoteams":
     cmd = UndoTeamsCommand()
+  elif command == "achievements":
+    cmd = AchievementsCommand()
 
   # Special command handling.
   if command_allowed(command, user_id):


### PR DESCRIPTION
I've implemented achievements functionality that is triggered by user behaviors, like invoke command, or win match. Currently only those two exist, and only the invoke behavior does anything, but more will come eventually.

The achievements' data is kept in "achievements.json" that is maintained by the `Achievements` manager. Upon a triggered behavior, `Achievements.interact()` will be called with it so that it can go through the list of known achievements instances and update them with the context of the behavior. Each achievement describes which types of behaviors it accepts, though.

Whenever an achievement is awarded they will be queued for next scheduled broadcast tick via `scheduled_actions()`.

Achievements in this PR based on [this list](https://github.com/netromdk/tourney/wiki/Achievements)
* RTFM
* Commander