### PR TITLE
Teamname command can forget current teamname

### DIFF
--- a/tourney/commands/help_command.py
+++ b/tourney/commands/help_command.py
@@ -23,7 +23,9 @@ As the foosball bot, I accept the following commands:
   `!allstats` - Prints general statistics of all games.
   `!mystats` - Prints statistics of all games about invoker.
   `!achievements` - Prints achievements progress for invoker.
-  `!teamname` - Set a teamname for your team. Call without argument to claim current name.
+  `!teamname` - Set a team name for your team.
+                Call without argument to claim your current team name.
+                Claim the teamname you already have to "forget" it instead.
                 Example: `!teamname Example Name`
   `!undoteams` - Undoes teams and matches and restores as players joined. (*privileged!*)
   `!generate` - Generate teams and matches from players joined. (*privileged!*)

--- a/tourney/commands/teamname_command.py
+++ b/tourney/commands/teamname_command.py
@@ -39,24 +39,10 @@ class TeamnameCommand(Command):
       response = "Cannot assign team name when player appears in multiple teams."
       return response
 
-    teamname = self.args()
-
     my_team = my_teams[0]
     team_idx = current_teams.index(my_team)
 
-    if len(teamname) == 0:
-      # Claiming current teamname
-      teamname = current_teamnames[team_idx]
-
-    # Saving chosen name for the team
-    teamnames.add(my_team, teamname)
-    teamnames.save()
-
-    # Updating state
-    current_teamnames[team_idx] = teamname
-    state.set_team_names(current_teamnames)
-    state.save()
-
+    # Output players in team
     # Prepend ", " or " and " before all non-first entries
     amount = len(my_team)
     for idx in range(amount):
@@ -68,6 +54,28 @@ class TeamnameCommand(Command):
         else:
           response += ", "
       response += lookup.user_name_by_id(my_team[idx])
+
+    teamname = self.args()
+
+    if len(teamname) == 0:
+      # Using current name as team name
+      teamname = current_teamnames[team_idx]
+
+    prev_teamname = teamnames.teamname(my_team)
+    if teamname == prev_teamname:
+      # Calling teamname while already holding the claimed name unclaims it
+      teamnames.remove(my_team)
+      response += " have denounced the name {}".format(teamname)
+      return response
+
+    # Saving chosen name for the team
+    teamnames.add(my_team, teamname)
+    teamnames.save()
+
+    # Updating state
+    current_teamnames[team_idx] = teamname
+    state.set_team_names(current_teamnames)
+    state.save()
 
     response += " will henceforth be known as {}".format(teamname)
     return response

--- a/tourney/teamnames.py
+++ b/tourney/teamnames.py
@@ -25,11 +25,14 @@ class Teamnames:
 
   def add(self, team, teamname):
     """Add a teamname for a given team."""
-    team_set = set(team)
     # Remove old teamname
-    self.__teamnames = [x for x in self.__teamnames if set(x[0]) != team_set]
+    self.remove(team)
     # Add the new one
     self.__teamnames.append([team, teamname])
+
+  def remove(self, team):
+    team_set = set(team)
+    self.__teamnames = [x for x in self.__teamnames if set(x[0]) != team_set]
 
   def teamname(self, team):
     team_set = set(team)


### PR DESCRIPTION
Calling teamname with the name of your current team makes teamnames forget it.

This also means that calling teamname with no argument _while you already have your remembered teamname_ also makes it forget.

So effectively you can call !teamname once to claim the name and then someone else could undo that if they wanted by just calling it again.
Or if you get a "remembered" teamname after scheduling and think "no this sucks, I would rather have random names in future for this team" you can just call !teamname and it will forget it. (I don't think this should **change** the current teamname, though, just so people don't spam it to get good names)