### PR TITLE
Automatically determine season from date

### DIFF
--- a/tourney/achievements/first_joiner_achievement.py
+++ b/tourney/achievements/first_joiner_achievement.py
@@ -6,12 +6,18 @@ from .behavior import JOIN_BEHAVIOR
 class FirstJoinerAchievement(TieredAchievement):
   def __init__(self):
     tiers = (
-      (1,   "Early Bird",    "Be the first player to join the game of the day."),
-      (5,   "Earlier Bird",  "Be the first player to join five times."),
-      (10,  "Earliest Bird", "Be the first player to join ten times."),
-      (25,  "Night Owl",     "Be the first player to join twenty five times."),
-      (50,  "Pterosaur",     "Earliest of the birds! Be the first player to join fifty times."),
-      (100, "Hipster",       "Joined before it was cool! Be the first player to join one hundred times."),
+      (1,   "Early Bird",
+       "Be the first player to join the game of the day."),
+      (5,   "Earlier Bird",
+       "Be the first player to join five times."),
+      (10,  "Earliest Bird",
+       "Be the first player to join ten times."),
+      (25,  "Night Owl",
+       "Be the first player to join twenty five times."),
+      (50,  "Pterosaur",
+       "Earliest of the birds! Be the first player to join fifty times."),
+      (100, "Hipster",
+       "Joined before it was cool! Be the first player to join one hundred times."),
     )
     super().__init__("FirstJoiner", tiers)
 

--- a/tourney/constants.py
+++ b/tourney/constants.py
@@ -1,10 +1,6 @@
 import sys
 from datetime import time, timedelta
 
-# Special seasons, with off-season mixin chance
-SEASONS = {"easter": 0.01, "halloween": 0.1, "xmas": 0.05, "dune": 0.01, "pirate_day": 0.1}
-SEASON = None
-
 # Will print all read events to stdout.
 DEBUG = False
 

--- a/tourney/season_checker.py
+++ b/tourney/season_checker.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+
+class Season:
+  def __init__(self, name, mixin, start_date, end_date):
+    self.name = name
+    self.mixin = mixin
+    self.start_date = start_date
+    self.end_date = end_date
+
+  def is_within(self, date):
+    date_md = (date.month, date.day)
+
+    if self.start_date <= self.end_date:
+      return self.start_date <= date_md <= self.end_date
+
+    # Handle year-end wrap-around
+    return date_md >= self.start_date or date_md <= self.end_date
+
+class SeasonChecker:
+  __instance = None
+
+  def __init__(self):
+    if not SeasonChecker.__instance:
+      self.seasons = []
+      self.seasons.append(Season('easter', 0.01,
+                                 start_date=(3, 1), end_date=(4, 31)))
+      self.seasons.append(Season('halloween', 0.1,
+                                 start_date=(10, 1), end_date=(10, 31)))
+      self.seasons.append(Season('xmas', 0.05,
+                                 start_date=(12, 1), end_date=(12, 31)))
+      self.seasons.append(Season('pirate_day', 0.1,
+                                 start_date=(9, 19), end_date=(9, 19)))
+      SeasonChecker.__instance = self
+
+  @staticmethod
+  def get():
+    if not SeasonChecker.__instance:
+      return SeasonChecker()
+    return SeasonChecker.__instance
+
+  def get_season(self):
+    for season in self.seasons:
+      if season.is_within(datetime.now()):
+        return season.name
+    return None
+
+  def get_seasons(self):
+    return self.seasons

--- a/tourney/teamname_generator.py
+++ b/tourney/teamname_generator.py
@@ -1,5 +1,5 @@
 from random import sample, choice, random, choices, shuffle
-from .constants import SEASON, SEASONS
+from .season_checker import SeasonChecker
 
 TEAM_NAMES = [
   "Air Farce",
@@ -828,18 +828,21 @@ def parts_for_season(season=None):
 
 def n_parts_by_season(n=1):
   # Decide how many parts to sample from each season
+  season_checker = SeasonChecker.get()
+  season = season_checker.get_season()
+
   nparts_by_season = {}
-  if SEASON is None:
-    p_none = 1 - sum(SEASONS.values())
-    # Split SEASONS into lists
-    seasons, probs = map(list, zip(*SEASONS.items()))
-    seasons.append(None)
-    probs.append(p_none)
-    part_seasons = choices(seasons, weights=probs, k=n)  # nosec
-    print(part_seasons)
+  if season is None:
+    seasons = season_checker.get_seasons()
+    season_mixins = [s.mixin for s in seasons]
+    season_names = [s.name for s in seasons]
+    p_none = 1 - sum(season_mixins)
+    season_names.append(None)
+    season_mixins.append(p_none)
+    part_seasons = choices(season_names, weights=season_mixins, k=n)  # nosec
     nparts_by_season = {s: part_seasons.count(s) for s in set(part_seasons)}
   else:
-    nparts_by_season[SEASON] = n
+    nparts_by_season[season] = n
 
   return nparts_by_season
 
@@ -911,7 +914,9 @@ def generate_teamnames(nteams):
 def generate_teamname():
   teamname = ""
   r = random()  # nosec
-  if r < 0.1 and SEASON is None:
+  season_checker = SeasonChecker.get()
+  season = season_checker.get_season()
+  if r < 0.1 and season is None:
     # Only use pre-defined teamnames outside of special seasons, p=0.1
     teamname = choice(TEAM_NAMES)  # nosec
   elif r < 0.9:


### PR DESCRIPTION
Seasons now have date ranges.
When generating team names, convert date to (month, day) and compare lexographically to the date range for each season.

Future work:
- More accurate dates for easter (there are packages for this or we could go down the lunar calendar rabbit hole)
- Season start announcements when `get_season(yesterday) != get_season(today)`?
- This enables more one-day seasons since you don't have to fuck around in constants to change things. So more of those. Towel Day, Guy Fawkes' Night, Valentine's, 4th of July, etc.

Also it's SPOOKY SEASON now 👻 